### PR TITLE
fix: replace completed HashSet with completed_count u64 to prevent unbounded memory growth

### DIFF
--- a/rust/src/orchestrator/mod.rs
+++ b/rust/src/orchestrator/mod.rs
@@ -328,7 +328,7 @@ impl<T: Tracker + 'static, A: AgentRunner + 'static> Orchestrator<T, A> {
                 Ok(()) => {
                     info!(issue_id = %issue_id, identifier = %identifier, "Worker finished successfully");
                     // Record this issue as having had at least one successful turn.
-                    state.completed.insert(issue_id.clone());
+                    state.completed_count += 1;
                     // Normal exit -> 1s continuation delay. Reset consecutive failure count.
                     let tx = self.tx.clone();
                     let id = issue_id.clone();

--- a/rust/src/orchestrator/state.rs
+++ b/rust/src/orchestrator/state.rs
@@ -91,8 +91,8 @@ pub struct OrchestratorState {
     pub claimed: HashSet<String>,
     /// Retry queue
     pub retry_attempts: HashMap<String, RetryEntry>,
-    /// Completed issue IDs
-    pub completed: HashSet<String>,
+    /// Count of successfully completed agent runs (monotonically increasing)
+    pub completed_count: u64,
     /// Aggregate token totals
     pub agent_totals: crate::domain::TokenTotals,
     /// Rate limit info (if any)
@@ -108,7 +108,7 @@ impl OrchestratorState {
             running: HashMap::new(),
             claimed: HashSet::new(),
             retry_attempts: HashMap::new(),
-            completed: HashSet::new(),
+            completed_count: 0,
             agent_totals: crate::domain::TokenTotals::new(),
             rate_limits: None,
         }
@@ -153,7 +153,7 @@ impl OrchestratorState {
             generated_at: Utc::now(),
             running_count: running.len(),
             retrying_count: retrying.len(),
-            completed_count: self.completed.len(),
+            completed_count: self.completed_count as usize,
             running,
             retrying,
             agent_totals,
@@ -188,5 +188,20 @@ mod tests {
         assert_eq!(snapshot.running_count, 0);
         assert_eq!(snapshot.retrying_count, 0);
         assert!(snapshot.running.is_empty());
+    }
+
+    #[test]
+    fn completed_count_is_u64_not_hashset() {
+        let config = AppConfig::default();
+        let mut state = OrchestratorState::new(&config);
+
+        assert_eq!(state.completed_count, 0);
+        state.completed_count += 1;
+        assert_eq!(state.completed_count, 1);
+        state.completed_count += 1;
+        assert_eq!(state.completed_count, 2);
+
+        let snapshot = state.to_snapshot();
+        assert_eq!(snapshot.completed_count, 2);
     }
 }


### PR DESCRIPTION
#### Context

completed: HashSet<String> stored every successfully processed issue_id indefinitely. In a long-running service this grows without bound — each unique issue_id is a ~40-80 byte String allocation that is never freed. The set was used only for completed_count display; deduplication is handled by the claimed set.

#### TL;DR

*Replace the completed HashSet with a plain u64 counter, eliminating O(n) memory growth while keeping completed_count observable.*

#### Summary

- Replace pub completed: HashSet<String> with pub completed_count: u64 in OrchestratorState
- Replace state.completed.insert(issue_id) with state.completed_count += 1 in handle_worker_finished
- Update to_snapshot() to use self.completed_count directly
- Add completed_count_is_u64_not_hashset unit test

#### Alternatives

- LRU cache with capacity bound: more complex, retains some historical data — not needed since the set is not used for lookups
- TTL-based eviction: adds time complexity — unnecessary for a pure counter

#### Test Plan

- [ ] `make -C elixir all`
- [x] `completed_count_is_u64_not_hashset`: verifies field is u64, increments correctly, surfaces in snapshot
- [x] All 167 tests pass